### PR TITLE
fw3.6

### DIFF
--- a/internal/rle/rle.go
+++ b/internal/rle/rle.go
@@ -41,16 +41,16 @@ func (rlewriter *RLE) Write(data []byte) (n int, err error) {
 	defer encodedPool.Put(encoded)
 
 	current := data[0]
-	count := -1
+	count := 0
 
 	for _, datum := range data {
-		if count < 255 && datum == current {
+		if count < 254 && datum == current {
 			count++
 		} else {
 			encoded = append(encoded, uint8(count))
 			encoded = append(encoded, uint8(current))
 			current = datum
-			count = 0
+			count = 1
 		}
 	}
 


### PR DESCRIPTION
- feat: add an endpoint and a devmode to get the raw picture
- feat: full memory region with FW 3.6 for analysis
- feat: exploration
- fix(wip); almost working version without REL
- feat(wip): gotcha little picture
- fix: skip the first 8 bytes after reverse engineering
- fix: unfli and extract the image
- feat: temporary version with gzip compression
- fix: colors
- fix(rle): not using a 15 pack encoding anymore
- fix: to be tested
- chore: update the readme
- chore: housekeeping
- fix: an odd number of byte was misinterpreted
- fix: rle
