### PR TITLE
Make sure background-color of body is white

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -3,6 +3,7 @@ body, html {
 	margin: 0;
 	padding: 0;
 	height: 100%;
+	background-color: white;
 }
 
 #container {


### PR DESCRIPTION
On systems with a dark theme it is not guaranteed that the html/body background-color is white. In that case the canvas will be distorted and fail to remove old elements.

This enforces a white background color.

Before:
![image](https://github.com/owulveryck/goMarkableStream/assets/2362091/13fe54da-563d-43a2-8279-ffe447bcf130)

After:
![image](https://github.com/owulveryck/goMarkableStream/assets/2362091/c9ddff30-3a8a-4743-adcb-063ef249fcaa)
