### PR TITLE
feat: skip HTTP auth when connected via USB

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -3,14 +3,17 @@ package main
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/owulveryck/goMarkableStream/internal/remarkable"
 )
 
 // BasicAuthMiddleware is a middleware function that adds basic authentication to a handler
 func BasicAuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		skipAuth := remarkable.HostsIP(r.RemoteAddr)
 		// Check if the request is authenticated
 		user, pass, ok := r.BasicAuth()
-		if !ok || !checkCredentials(user, pass) {
+		if !skipAuth && (!ok || !checkCredentials(user, pass)) {
 			// Authentication failed, send a 401 Unauthorized response
 			w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
 			w.WriteHeader(http.StatusUnauthorized)

--- a/internal/remarkable/ip.go
+++ b/internal/remarkable/ip.go
@@ -1,0 +1,49 @@
+package remarkable
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+)
+
+func HostsIP(addr string) bool {
+	if strings.Contains(addr, ":") {
+		addr = addr[:strings.Index(addr, ":")]
+	}
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return false
+	}
+
+	mask, err := getMask()
+	if err != nil {
+		return false
+	}
+
+	return mask.Contains(ip)
+}
+
+func getMask() (*net.IPNet, error) {
+	iface, err := net.InterfaceByName("usb1")
+	if err != nil {
+		return nil, fmt.Errorf("failed to locate usb1 interface: %w", err)
+	}
+
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return nil, fmt.Errorf("failed to enumerate ips for usb1 interface: %w", err)
+	}
+
+	for _, addr := range addrs {
+		ip, mask, err := net.ParseCIDR(addr.String())
+		if err != nil {
+			continue
+		}
+
+		if strings.HasSuffix(ip.String(), ".1") {
+			return mask, nil
+		}
+	}
+	return nil, errors.New("no expected ip found on usb interface")
+}


### PR DESCRIPTION
When connected via USB it doesn't make a whole lot of sense to ask for a password.