### PR TITLE
feat: add parameter `flip` to the client endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Add query parameters to the URL (`?parameter=value&otherparameter=value`):
 - `color`: (true/false) Enable or disable color.
 - `portrait`: (true/false) Enable or disable portrait mode.
 - `rate`: (integer, 100-...) Set the frame rate.
+- `flip`: (true/false) Enable or disable flipping 180 degree.
 
 ## Tunneling
 Tunneling with built-in Ngrok allows for streaming across different networks.

--- a/client/canvasHandling.js
+++ b/client/canvasHandling.js
@@ -28,6 +28,12 @@ function resizeVisibleCanvas() {
 		visibleCanvas.style.width = containerWidth + "px";
 		visibleCanvas.style.height = containerWidth / aspectRatio + "px";
 	}
+
+	if (flip) {
+		visibleCanvas.style.transform = "rotate(180deg)";
+	} else {
+		visibleCanvas.style.transform = "rotate(0deg)";
+	}
 }
 function waiting(message) {
 	// Clear the canvas

--- a/client/main.js
+++ b/client/main.js
@@ -4,6 +4,8 @@ const height = 1404;
 const rawCanvas = new OffscreenCanvas(width, height); // Define width and height as needed
 let portrait = getQueryParam('portrait');
 portrait = portrait !== null ? portrait === 'true' : false;
+let flip = getQueryParam('flip');
+flip = flip !== null ? flip === 'true' : false;
 let withColor = getQueryParam('color', 'true');
 withColor = withColor !== null ? withColor === 'true' : true;
 let rate = parseInt(getQueryParamOrDefault('rate', '200'), 10);


### PR DESCRIPTION
There are four orientations in total for the reMarkable 2 screen: two for portrait and two for landscape.
When the orientation of the reMarkable 2 screen changes, I also want goMarkableStream to rotate.
Since there is already an endpoint parameter `portrait` to control the portrait or landscape, I add another parameter `flip` to control if it needs to rotate 180 degrees at each case.