### PR TITLE
Add initial support for Remarkable Paper Pro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+export GOOS ?= linux
+export CGO_ENABLED ?= 0
+export GOARCH ?= amd64
+
+.PHONY: build-remarkable-2
+build-remarkable-2: GOARCH=arm
+build-remarkable-2: build
+
+.PHONY: build-remarkable-paper-pro
+build-remarkable-paper-pro: GOARCH=arm64
+build-remarkable-paper-pro: build
+
+.PHONY: build
+build:
+	@echo "Building for GOOS=${GOOS}, GOARCH=${GOARCH}, CGO_ENABLED=${CGO_ENABLED}"
+	go build -v -trimpath -ldflags="-s -w" .

--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ The goMarkableStream is a lightweight and user-friendly application designed spe
 
 Its primary goal is to enable users to stream their reMarkable tablet screen to a web browser without the need for any hacks or modifications that could void the warranty.
 
+## Device support
+
+- Remarkable 2
+- Remarkable Paper Pro (see notes below)
+
+### Remarkable Paper Pro
+
+Remarkable Paper Pro is in initial support. The application is not yet fully tested on this device and some features may not work as expected.
+
+When running on the Remarkable Paper Pro, `RLE_COMPRESSION` environment variable must be set to `false` since it's not supported.
+
 ## Version support
 
 - reMarkable with firmware < 3.4 may use goMarkableStream version < 0.8.6
@@ -122,6 +133,9 @@ Configure the application via environment variables:
 - `RK_HTTPS`: (True/False, default: `true`) Enable or disable HTTPS.
 - `RK_COMPRESSION`: (True/False, default: `false`) Enable or disable compression.
 - `RK_DEV_MODE`: (True/False, default: `false`) Enable or disable developer mode.
+- `RLE_COMPRESSION`: (True/False, default: `true`) Enable or disable RLE compression.
+- `ZSTD_COMPRESSION`: (True/False, default: `false`) Enable or disable ZSTD compression.
+- `ZSTD_COMPRESSION_LEVEL`: (Integer, default: `3`) Set the ZSTD compression level.
 
 ### Endpoint Configuration
 Add query parameters to the URL (`?parameter=value&otherparameter=value`):

--- a/client/canvasHandling.js
+++ b/client/canvasHandling.js
@@ -3,9 +3,9 @@ function resizeVisibleCanvas() {
 	var container = document.getElementById("container");
 
 	if (portrait) {
-		var aspectRatio = 1404 / 1872;
+		var aspectRatio = screenHeight / screenWidth;
 	} else {
-		var aspectRatio = 1872 / 1404;
+		var aspectRatio = screenWidth / screenHeight;
 	}
 
 	var containerWidth = container.offsetWidth;

--- a/client/glCanvas.js
+++ b/client/glCanvas.js
@@ -160,7 +160,7 @@ gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
 // gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
 
 // Upload the image into the texture.
-let imageData = new ImageData(width, height);
+let imageData = new ImageData(screenWidth, screenHeight);
 gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, imageData);
 
 // Draw the scene
@@ -209,7 +209,7 @@ drawScene(gl, programInfo, positionBuffer, textureCoordBuffer, texture);
 // Update texture
 function updateTexture(newRawData, shouldRotate, scaleFactor) {
 	gl.bindTexture(gl.TEXTURE_2D, texture);
-	gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, newRawData);
+	gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, screenWidth, screenHeight, gl.RGBA, gl.UNSIGNED_BYTE, newRawData);
 
 	// Set rotation
 	const uRotationMatrixLocation = gl.getUniformLocation(shaderProgram, 'uRotationMatrix');
@@ -243,9 +243,8 @@ function resizeGLCanvas(canvas) {
 }
 
 function updateLaserPosition(x, y) {
-
-	laserX = x / 1872 * gl.canvas.width;
-	laserY = gl.canvas.height - (y / 1404 * gl.canvas.height);
+	laserX = x / screenWidth * gl.canvas.width;
+	laserY = gl.canvas.height - (y / screenHeight * gl.canvas.height);
 
     drawScene(gl, programInfo, positionBuffer, textureCoordBuffer, texture);
 }

--- a/client/glCanvas.js
+++ b/client/glCanvas.js
@@ -131,16 +131,25 @@ const programInfo = {
 const textureCoordBuffer = gl.createBuffer();
 gl.bindBuffer(gl.ARRAY_BUFFER, textureCoordBuffer);
 
-const textureCoordinates = [
-//	1.0,  0.0,  // Bottom right
-//	0.0,  0.0,  // Bottom left
-//	1.0,  1.0,  // Top right
-//	0.0,  1.0,  // Top left
-	1.0, 1.0,
-	0.0, 1.0,
-	1.0, 0.0,
-	0.0, 0.0,
-];
+const textureCoordinates = getTextureCoordinates();
+
+function getTextureCoordinates() {
+    if (DeviceModel === "Remarkable2") {
+        return [
+			1.0, 1.0,
+			0.0, 1.0,
+			1.0, 0.0,
+			0.0, 0.0,
+		];
+    } else {
+        return [
+			1.0, 0.0,
+			0.0, 0.0,
+			1.0, 1.0,
+			0.0, 1.0,
+		];
+    };
+};
 
 gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(textureCoordinates), gl.STATIC_DRAW);
 
@@ -208,6 +217,10 @@ drawScene(gl, programInfo, positionBuffer, textureCoordBuffer, texture);
 
 // Update texture
 function updateTexture(newRawData, shouldRotate, scaleFactor) {
+	if (useBGRA) {
+        convertBGRAtoRGBA(newRawData);
+    };
+
 	gl.bindTexture(gl.TEXTURE_2D, texture);
 	gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, screenWidth, screenHeight, gl.RGBA, gl.UNSIGNED_BYTE, newRawData);
 
@@ -221,6 +234,14 @@ function updateTexture(newRawData, shouldRotate, scaleFactor) {
 	gl.uniform1f(uScaleFactorLocation, scaleFactor);
 
 	drawScene(gl, programInfo, positionBuffer, textureCoordBuffer, texture);
+}
+
+function convertBGRAtoRGBA(data) {
+    for (let i = 0; i < data.length; i += 4) {
+        const b = data[i];     // Blue
+        data[i] = data[i + 2]; // Swap Red and Blue
+        data[i + 2] = b;
+    }
 }
 
 // Call `updateTexture` with new data whenever you need to update the image

--- a/client/index.html
+++ b/client/index.html
@@ -5,6 +5,10 @@
 		<link rel="icon" type="image/x-icon" href="favicon.ico">
 		<!-- Including the CSS stylesheet -->
 		<link rel="stylesheet" href="style.css">
+        <script>
+            const screenWidth = {{ .ScreenWidth }};
+            const screenHeight = {{ .ScreenHeight }};
+        </script>
 	</head>
 	<body>
 		<div id="menuContainer">

--- a/client/index.html
+++ b/client/index.html
@@ -10,6 +10,8 @@
             const screenHeight = {{ .ScreenHeight }};
 			const MaxXValue = {{ .MaxXValue }};
 			const MaxYValue = {{ .MaxYValue }};
+			const UseRLE = {{ .UseRLE }};
+			const DeviceModel = {{ .DeviceModel }};
         </script>
 	</head>
 	<body>

--- a/client/index.html
+++ b/client/index.html
@@ -8,6 +8,8 @@
         <script>
             const screenWidth = {{ .ScreenWidth }};
             const screenHeight = {{ .ScreenHeight }};
+			const MaxXValue = {{ .MaxXValue }};
+			const MaxYValue = {{ .MaxYValue }};
         </script>
 	</head>
 	<body>

--- a/client/main.js
+++ b/client/main.js
@@ -1,7 +1,4 @@
-const width = 1872;
-const height = 1404;
-
-const rawCanvas = new OffscreenCanvas(width, height); // Define width and height as needed
+const rawCanvas = new OffscreenCanvas(screenWidth, screenHeight); // Define width and height as needed
 let portrait = getQueryParam('portrait');
 portrait = portrait !== null ? portrait === 'true' : false;
 let flip = getQueryParam('flip');
@@ -29,7 +26,7 @@ function getQueryParamOrDefault(param, defaultValue) {
     const value = urlParams.get(param);
     return value !== null ? value : defaultValue;
 }
-//let imageData = ctx.createImageData(width, height); // width and height of your canvas
+//let imageData = ctx.createImageData(screenWidth, screenHeight); // width and height of your canvas
 function getQueryParam(name) {
 	const urlParams = new URLSearchParams(window.location.search);
 	return urlParams.get(name);

--- a/client/main.js
+++ b/client/main.js
@@ -1,12 +1,23 @@
 const rawCanvas = new OffscreenCanvas(screenWidth, screenHeight); // Define width and height as needed
 let portrait = getQueryParam('portrait');
 portrait = portrait !== null ? portrait === 'true' : false;
-let flip = getQueryParam('flip');
-flip = flip !== null ? flip === 'true' : false;
+
+defaultFlip = true;
+// If this is the Paper Pro, we don't need to flip the image.
+if (DeviceModel === 'RemarkablePaperPro') {
+	defaultFlip = false;
+}
+let flip = getBoolQueryParam('flip', defaultFlip);
+
 let withColor = getQueryParam('color', 'true');
 withColor = withColor !== null ? withColor === 'true' : true;
 let rate = parseInt(getQueryParamOrDefault('rate', '200'), 10);
 
+// Remarkable Paper Pro uses BGRA format.
+let useBGRA = false;
+if (DeviceModel === 'RemarkablePaperPro') {
+	useBGRA = true;
+};
 
 //let portrait = false;
 // Get the 'present' parameter from the URL
@@ -26,12 +37,22 @@ function getQueryParamOrDefault(param, defaultValue) {
     const value = urlParams.get(param);
     return value !== null ? value : defaultValue;
 }
+
 //let imageData = ctx.createImageData(screenWidth, screenHeight); // width and height of your canvas
 function getQueryParam(name) {
 	const urlParams = new URLSearchParams(window.location.search);
 	return urlParams.get(name);
 }
 
+function getBoolQueryParam(param, defaultValue = false) {
+    value = getQueryParam(param);
+
+    if (value === null) {
+        return defaultValue;
+    }
+
+    return value === 'true';
+}
 
 window.onload = function() {
 	// Function to get the value of a query parameter by name

--- a/client/worker_event_processing.js
+++ b/client/worker_event_processing.js
@@ -5,8 +5,8 @@ let portrait;
 let draw; 
 let latestX;
 let latestY;
-const MAX_X_VALUE = 15725;
-const MAX_Y_VALUE = 20966;
+let maxXValue;
+let maxYValue;
 
 onmessage = (event) => {
 	const data = event.data;
@@ -17,6 +17,8 @@ onmessage = (event) => {
 			width = event.data.width;
 			eventURL = event.data.eventURL;
 			portrait = event.data.portrait;
+            maxXValue = event.data.maxXValue;
+            maxYValue = event.data.maxYValue;
 			initiateEventsListener();
 			break;
 		case 'portrait':
@@ -50,16 +52,16 @@ async function initiateEventsListener() {
 			// Code 3: Update and draw laser pointer
 			if (portrait) {
 				if (message.Code === 1) { // Horizontal position
-					latestX = scaleValue(message.Value, MAX_X_VALUE, width);
+					latestX = scaleValue(message.Value, maxXValue, width);
 				} else if (message.Code === 0) { // Vertical position
-					latestY = height - scaleValue(message.Value, MAX_Y_VALUE, height);
+					latestY = height - scaleValue(message.Value, maxYValue, height);
 				}
 			} else {
 				// wrong
 				if (message.Code === 1) { // Horizontal position
-					latestY = scaleValue(message.Value, MAX_X_VALUE, height);
+					latestY = scaleValue(message.Value, maxYValue, height);
 				} else if (message.Code === 0) { // Vertical position
-					latestX = scaleValue(message.Value, MAX_Y_VALUE, width);
+					latestX = scaleValue(message.Value, maxXValue, width);
 				}
 			}
 			if (draw) {

--- a/client/workersHandling.js
+++ b/client/workersHandling.js
@@ -4,7 +4,8 @@ streamWorker.postMessage({
 	width: screenWidth,
 	height: screenHeight,
 	rate: rate,
-	withColor: withColor
+	withColor: withColor,
+	useRLE: UseRLE,
 });
 
 

--- a/client/workersHandling.js
+++ b/client/workersHandling.js
@@ -39,7 +39,9 @@ eventWorker.postMessage({
 	width: screenWidth,
 	height: screenHeight,
 	portrait: portrait,
-	eventURL: eventURL
+	eventURL: eventURL,
+    maxXValue: MaxXValue,
+    maxYValue: MaxYValue,
 });
 gestureWorker.postMessage({ 
 	type: 'init', 

--- a/client/workersHandling.js
+++ b/client/workersHandling.js
@@ -1,8 +1,8 @@
 // Send the OffscreenCanvas to the worker for initialization
 streamWorker.postMessage({ 
 	type: 'init', 
-	width: width, 
-	height: height,
+	width: screenWidth,
+	height: screenHeight,
 	rate: rate,
 	withColor: withColor
 });
@@ -36,8 +36,8 @@ const eventURL = `/events`;
 // Send the OffscreenCanvas to the worker for initialization
 eventWorker.postMessage({ 
 	type: 'init', 
-	width: width, 
-	height: height, 
+	width: screenWidth,
+	height: screenHeight,
 	portrait: portrait,
 	eventURL: eventURL
 });

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22
 
 require (
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/klauspost/compress v1.17.11
 	golang.ngrok.com/ngrok v1.4.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2E
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
+github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
+github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=

--- a/http.go
+++ b/http.go
@@ -1,15 +1,15 @@
 package main
 
 import (
-	"bytes"
 	"crypto/tls"
-	"io"
+	"html/template"
 	"log"
 	"net"
 	"net/http"
 
 	"github.com/owulveryck/goMarkableStream/internal/eventhttphandler"
 	"github.com/owulveryck/goMarkableStream/internal/pubsub"
+	"github.com/owulveryck/goMarkableStream/internal/remarkable"
 	"github.com/owulveryck/goMarkableStream/internal/stream"
 )
 
@@ -24,20 +24,8 @@ func (s stripFS) Open(name string) (http.File, error) {
 func setMuxer(eventPublisher *pubsub.PubSub) *http.ServeMux {
 	mux := http.NewServeMux()
 
-	fs := http.FileServer(stripFS{http.FS(assetsFS)})
-
 	// Custom handler to serve index.html for root path
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/" {
-			index, err := assetsFS.ReadFile("client/index.html")
-			if err != nil {
-				log.Fatal(err)
-			}
-			io.Copy(w, bytes.NewReader(index))
-			return
-		}
-		fs.ServeHTTP(w, r)
-	})
+	mux.HandleFunc("/", newIndexHandler(stripFS{http.FS(assetsFS)}))
 
 	streamHandler := stream.NewStreamHandler(file, pointerAddr, eventPublisher)
 	if c.Compression {
@@ -56,6 +44,52 @@ func setMuxer(eventPublisher *pubsub.PubSub) *http.ServeMux {
 		mux.Handle("/raw", rawHandler)
 	}
 	return mux
+}
+
+func parseIndexTemplate(templatePath string) (*template.Template, error) {
+	indexData, err := assetsFS.ReadFile(templatePath)
+	if err != nil {
+		return nil, err
+	}
+
+	tmpl, err := template.New("index.html").Parse(string(indexData))
+	if err != nil {
+		return nil, err
+	}
+
+	return tmpl, nil
+}
+
+func newIndexHandler(fs http.FileSystem) http.HandlerFunc {
+	tmpl, err := parseIndexTemplate("client/index.html")
+	if err != nil {
+		log.Fatalf("Error parsing index template: %v", err)
+		panic(err)
+	}
+
+	staticFileServer := http.FileServer(fs)
+
+	data := struct {
+		ScreenWidth  int
+		ScreenHeight int
+	}{
+		ScreenWidth:  remarkable.ScreenWidth,
+		ScreenHeight: remarkable.ScreenHeight,
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			w.Header().Set("Content-Type", "text/html")
+			if err := tmpl.Execute(w, data); err != nil {
+				http.Error(w, "Error rendering template", http.StatusInternalServerError)
+				log.Printf("Error rendering template: %v", err)
+			}
+			return
+		} else {
+
+			staticFileServer.ServeHTTP(w, r)
+		}
+	}
 }
 
 func runTLS(l net.Listener, handler http.Handler) error {

--- a/http.go
+++ b/http.go
@@ -27,7 +27,7 @@ func setMuxer(eventPublisher *pubsub.PubSub) *http.ServeMux {
 	// Custom handler to serve index.html for root path
 	mux.HandleFunc("/", newIndexHandler(stripFS{http.FS(assetsFS)}))
 
-	streamHandler := stream.NewStreamHandler(file, pointerAddr, eventPublisher)
+	streamHandler := stream.NewStreamHandler(file, pointerAddr, eventPublisher, c.RLECompression)
 	if c.Compression {
 		mux.Handle("/stream", gzMiddleware(stream.ThrottlingMiddleware(streamHandler)))
 	} else {
@@ -74,11 +74,15 @@ func newIndexHandler(fs http.FileSystem) http.HandlerFunc {
 		ScreenHeight int
 		MaxXValue    int
 		MaxYValue    int
+		UseRLE       bool
+		DeviceModel  string
 	}{
 		ScreenWidth:  remarkable.ScreenWidth,
 		ScreenHeight: remarkable.ScreenHeight,
 		MaxXValue:    remarkable.MaxXValue,
 		MaxYValue:    remarkable.MaxYValue,
+		UseRLE:       c.RLECompression,
+		DeviceModel:  remarkable.Model.String(),
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/http.go
+++ b/http.go
@@ -72,9 +72,13 @@ func newIndexHandler(fs http.FileSystem) http.HandlerFunc {
 	data := struct {
 		ScreenWidth  int
 		ScreenHeight int
+		MaxXValue    int
+		MaxYValue    int
 	}{
 		ScreenWidth:  remarkable.ScreenWidth,
 		ScreenHeight: remarkable.ScreenHeight,
+		MaxXValue:    remarkable.MaxXValue,
+		MaxYValue:    remarkable.MaxYValue,
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/http.go
+++ b/http.go
@@ -30,6 +30,8 @@ func setMuxer(eventPublisher *pubsub.PubSub) *http.ServeMux {
 	streamHandler := stream.NewStreamHandler(file, pointerAddr, eventPublisher, c.RLECompression)
 	if c.Compression {
 		mux.Handle("/stream", gzMiddleware(stream.ThrottlingMiddleware(streamHandler)))
+	} else if c.ZSTDCompression {
+		mux.Handle("/stream", zstdMiddleware(stream.ThrottlingMiddleware(streamHandler), c.ZSTDCompressionLevel))
 	} else {
 		mux.Handle("/stream", stream.ThrottlingMiddleware(streamHandler))
 	}

--- a/internal/remarkable/const.go
+++ b/internal/remarkable/const.go
@@ -1,4 +1,4 @@
-//go:build linux && !arm64
+//go:build !arm64
 
 package remarkable
 
@@ -9,4 +9,7 @@ const (
 	ScreenHeight = 1404
 
 	ScreenSize = ScreenWidth * ScreenHeight * 2
+
+	PenInputDevice   = "/dev/input/event1"
+	TouchInputDevice = "/dev/input/event2"
 )

--- a/internal/remarkable/const.go
+++ b/internal/remarkable/const.go
@@ -10,7 +10,7 @@ const (
 	// ScreenHeight of the remarkable 2
 	ScreenHeight = 1404
 
-	ScreenSize = ScreenWidth * ScreenHeight * 2
+	ScreenSizeBytes = ScreenWidth * ScreenHeight * 2
 
 	// These values are from Max values of /dev/input/event1 (ABS_X and ABS_Y)
 	MaxXValue = 15725

--- a/internal/remarkable/const.go
+++ b/internal/remarkable/const.go
@@ -1,3 +1,5 @@
+//go:build linux && !arm64
+
 package remarkable
 
 const (
@@ -5,4 +7,6 @@ const (
 	ScreenWidth = 1872
 	// ScreenHeight of the remarkable 2
 	ScreenHeight = 1404
+
+	ScreenSize = ScreenWidth * ScreenHeight * 2
 )

--- a/internal/remarkable/const.go
+++ b/internal/remarkable/const.go
@@ -3,6 +3,8 @@
 package remarkable
 
 const (
+	Model = Remarkable2
+
 	// ScreenWidth of the remarkable 2
 	ScreenWidth = 1872
 	// ScreenHeight of the remarkable 2

--- a/internal/remarkable/const.go
+++ b/internal/remarkable/const.go
@@ -10,6 +10,10 @@ const (
 
 	ScreenSize = ScreenWidth * ScreenHeight * 2
 
+	// These values are from Max values of /dev/input/event1 (ABS_X and ABS_Y)
+	MaxXValue = 15725
+	MaxYValue = 20966
+
 	PenInputDevice   = "/dev/input/event1"
 	TouchInputDevice = "/dev/input/event2"
 )

--- a/internal/remarkable/const_arm64.go
+++ b/internal/remarkable/const_arm64.go
@@ -10,7 +10,7 @@ const (
 	// ScreenHeight of the remarkable paper pro
 	ScreenHeight = 2154
 
-	ScreenSize = ScreenWidth * ScreenHeight * 4
+	ScreenSizeBytes = ScreenWidth * ScreenHeight * 4
 
 	// These values are from Max values of /dev/input/event2 (ABS_X and ABS_Y)
 	MaxXValue = 11180

--- a/internal/remarkable/const_arm64.go
+++ b/internal/remarkable/const_arm64.go
@@ -6,9 +6,9 @@ const (
 	Model = RemarkablePaperPro
 
 	// ScreenWidth of the remarkable paper pro
-	ScreenWidth = 1624
+	ScreenWidth = 1620
 	// ScreenHeight of the remarkable paper pro
-	ScreenHeight = 2154
+	ScreenHeight = 2160
 
 	ScreenSizeBytes = ScreenWidth * ScreenHeight * 4
 

--- a/internal/remarkable/const_arm64.go
+++ b/internal/remarkable/const_arm64.go
@@ -6,9 +6,9 @@ const (
 	Model = RemarkablePaperPro
 
 	// ScreenWidth of the remarkable paper pro
-	ScreenWidth = 1620
+	ScreenWidth = 1624
 	// ScreenHeight of the remarkable paper pro
-	ScreenHeight = 2160
+	ScreenHeight = 2154
 
 	ScreenSizeBytes = ScreenWidth * ScreenHeight * 4
 

--- a/internal/remarkable/const_arm64.go
+++ b/internal/remarkable/const_arm64.go
@@ -1,4 +1,4 @@
-//go:build linux && arm64
+//go:build arm64
 
 package remarkable
 
@@ -9,4 +9,7 @@ const (
 	ScreenHeight = 1624
 
 	ScreenSize = ScreenWidth * ScreenHeight * 4
+
+	PenInputDevice   = "/dev/input/event2"
+	TouchInputDevice = "/dev/input/event3"
 )

--- a/internal/remarkable/const_arm64.go
+++ b/internal/remarkable/const_arm64.go
@@ -10,6 +10,10 @@ const (
 
 	ScreenSize = ScreenWidth * ScreenHeight * 4
 
+	// These values are from Max values of /dev/input/event2 (ABS_X and ABS_Y)
+	MaxXValue = 11180
+	MaxYValue = 15340
+
 	PenInputDevice   = "/dev/input/event2"
 	TouchInputDevice = "/dev/input/event3"
 )

--- a/internal/remarkable/const_arm64.go
+++ b/internal/remarkable/const_arm64.go
@@ -3,10 +3,12 @@
 package remarkable
 
 const (
+	Model = RemarkablePaperPro
+
 	// ScreenWidth of the remarkable paper pro
-	ScreenWidth = 2154
+	ScreenWidth = 1624
 	// ScreenHeight of the remarkable paper pro
-	ScreenHeight = 1624
+	ScreenHeight = 2154
 
 	ScreenSize = ScreenWidth * ScreenHeight * 4
 

--- a/internal/remarkable/const_arm64.go
+++ b/internal/remarkable/const_arm64.go
@@ -1,0 +1,12 @@
+//go:build linux && arm64
+
+package remarkable
+
+const (
+	// ScreenWidth of the remarkable paper pro
+	ScreenWidth = 2154
+	// ScreenHeight of the remarkable paper pro
+	ScreenHeight = 1624
+
+	ScreenSize = ScreenWidth * ScreenHeight * 4
+)

--- a/internal/remarkable/device.go
+++ b/internal/remarkable/device.go
@@ -1,0 +1,20 @@
+package remarkable
+
+type DeviceModel int
+
+const (
+	UnknownDevice DeviceModel = iota
+	Remarkable2
+	RemarkablePaperPro
+)
+
+func (d DeviceModel) String() string {
+	switch d {
+	case Remarkable2:
+		return "Remarkable2"
+	case RemarkablePaperPro:
+		return "RemarkablePaperPro"
+	default:
+		return "UnknownDevice"
+	}
+}

--- a/internal/remarkable/events_linux.go
+++ b/internal/remarkable/events_linux.go
@@ -20,11 +20,11 @@ type EventScanner struct {
 
 // NewEventScanner ...
 func NewEventScanner() *EventScanner {
-	pen, err := os.OpenFile("/dev/input/event1", os.O_RDONLY, 0o644)
+	pen, err := os.OpenFile(PenInputDevice, os.O_RDONLY, 0o644)
 	if err != nil {
 		log.Fatalf("failed to read pen position: %v", err)
 	}
-	touch, err := os.OpenFile("/dev/input/event2", os.O_RDONLY, 0o644)
+	touch, err := os.OpenFile(TouchInputDevice, os.O_RDONLY, 0o644)
 	if err != nil {
 		log.Fatalf("failed to read touch position: %v", err)
 	}

--- a/internal/remarkable/fb.go
+++ b/internal/remarkable/fb.go
@@ -1,4 +1,4 @@
-//go:build !linux || !arm
+//go:build !linux || (!arm && !arm64)
 
 package remarkable
 

--- a/internal/remarkable/fb_rm.go
+++ b/internal/remarkable/fb_rm.go
@@ -18,5 +18,4 @@ func GetFileAndPointer() (io.ReaderAt, int64, error) {
 		return file, 0, err
 	}
 	return file, pointerAddr, nil
-
 }

--- a/internal/remarkable/fb_rm.go
+++ b/internal/remarkable/fb_rm.go
@@ -1,4 +1,4 @@
-//go:build linux && arm
+//go:build linux && (arm || arm64)
 
 package remarkable
 

--- a/internal/remarkable/pointer.go
+++ b/internal/remarkable/pointer.go
@@ -1,3 +1,5 @@
+//go:build linux && !arm64
+
 package remarkable
 
 import (
@@ -28,5 +30,5 @@ func getFramePointer(pid string) (int64, error) {
 			scanAddr = true
 		}
 	}
-	return addr, err
+	return addr + 8, err
 }

--- a/internal/remarkable/pointer_arm64.go
+++ b/internal/remarkable/pointer_arm64.go
@@ -1,0 +1,113 @@
+//go:build linux && arm64
+
+package remarkable
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func getFramePointer(pid string) (int64, error) {
+	// Find the memory range for the framebuffer
+	startAddress, err := getMemoryRange(pid)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get memory range: %w", err)
+	}
+
+	// Calculate the correct starting address
+	framePointer, err := calculateFramePointer(pid, startAddress)
+	if err != nil {
+		return 0, fmt.Errorf("failed to calculate frame pointer: %w", err)
+	}
+
+	return framePointer, nil
+}
+
+// getMemoryRange retrieves the end address of the last /dev/dri/card0 entry from /proc/[pid]/maps
+func getMemoryRange(pid string) (int64, error) {
+	mapsFilePath := fmt.Sprintf("/proc/%s/maps", pid)
+	file, err := os.Open(mapsFilePath)
+	if err != nil {
+		return 0, fmt.Errorf("cannot open maps file: %w", err)
+	}
+	defer file.Close()
+
+	var memoryRange string
+	scanner := bufio.NewScanner(file)
+
+	// Find the last occurrence of /dev/dri/card0
+	// We need the memory mapping for the display, which is located immediately
+	// after the last /dev/dri/card0 mapping. Hence, we keep iterating through
+	// the file and update memoryRange each time we encounter /dev/dri/card0.
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "/dev/dri/card0") {
+			memoryRange = line
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("error reading maps file: %w", err)
+	}
+
+	if memoryRange == "" {
+		return 0, fmt.Errorf("no mapping found for /dev/dri/card0")
+	}
+
+	// Extract the end address of the last /dev/dri/card0 memory range
+	// The range is in the format: "start-end permissions offset dev inode pathname"
+	fields := strings.Fields(memoryRange)
+	rangeField := fields[0]
+	startEnd := strings.Split(rangeField, "-")
+	if len(startEnd) != 2 {
+		return 0, fmt.Errorf("invalid memory range format")
+	}
+
+	// We are interested in the end address because the next memory region,
+	// starting from this end address, contains the frame buffer we need.
+	end, err := strconv.ParseInt(startEnd[1], 16, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse end address: %w", err)
+	}
+
+	return end, nil
+}
+
+// calculateFramePointer finds the frame pointer using the end address and memory file
+func calculateFramePointer(pid string, startAddress int64) (int64, error) {
+	memFilePath := fmt.Sprintf("/proc/%s/mem", pid)
+	file, err := os.Open(memFilePath)
+	if err != nil {
+		return 0, fmt.Errorf("cannot open memory file: %w", err)
+	}
+	defer file.Close()
+
+	var offset int64
+	length := 2
+
+	// Iterate to calculate the correct offset within the frame buffer memory
+	// The memory header contains a length field (4 bytes) which we use to determine
+	// how much memory to skip. We dynamically calculate the offset until the
+	// buffer size (width x height x 4 bytes per pixel) is reached.
+	for length < ScreenSize {
+		offset += int64(length - 2)
+
+		// Seek to the start address plus offset and read the header
+		// The header helps identify the size of the subsequent memory block.
+		file.Seek(startAddress+offset+8, 0)
+		header := make([]byte, 8)
+		_, err := file.Read(header)
+		if err != nil {
+			return 0, fmt.Errorf("error reading memory header: %w", err)
+		}
+
+		// Extract the length from the header (4 bytes at the beginning of the header)
+		length = int(int64(header[0]) | int64(header[1])<<8 | int64(header[2])<<16 | int64(header[3])<<24)
+	}
+
+	// Return the calculated frame pointer address
+	return startAddress + offset, nil
+}

--- a/internal/remarkable/pointer_arm64.go
+++ b/internal/remarkable/pointer_arm64.go
@@ -92,7 +92,7 @@ func calculateFramePointer(pid string, startAddress int64) (int64, error) {
 	// The memory header contains a length field (4 bytes) which we use to determine
 	// how much memory to skip. We dynamically calculate the offset until the
 	// buffer size (width x height x 4 bytes per pixel) is reached.
-	for length < ScreenSize {
+	for length < ScreenSizeBytes {
 		offset += int64(length - 2)
 
 		// Seek to the start address plus offset and read the header

--- a/internal/rle/rle.go
+++ b/internal/rle/rle.go
@@ -16,7 +16,7 @@ var encodedPool = sync.Pool{
 
 var bufferPool = sync.Pool{
 	New: func() any {
-		return make([]byte, 0, remarkable.ScreenHeight*remarkable.ScreenWidth*2)
+		return make([]byte, 0, remarkable.ScreenSize)
 	},
 }
 
@@ -50,7 +50,7 @@ func (rlewriter *RLE) Write(data []byte) (int, error) {
 	current := data[0]
 	count := uint8(0)
 
-	for i := 0; i < remarkable.ScreenHeight*remarkable.ScreenWidth*2; i += 2 {
+	for i := 0; i < remarkable.ScreenSize; i += 2 {
 		datum := data[i]
 		if count < 254 && datum == current {
 			count++

--- a/internal/rle/rle.go
+++ b/internal/rle/rle.go
@@ -16,7 +16,7 @@ var encodedPool = sync.Pool{
 
 var bufferPool = sync.Pool{
 	New: func() any {
-		return make([]byte, 0, remarkable.ScreenSize)
+		return make([]byte, 0, remarkable.ScreenSizeBytes)
 	},
 }
 
@@ -50,7 +50,7 @@ func (rlewriter *RLE) Write(data []byte) (int, error) {
 	current := data[0]
 	count := uint8(0)
 
-	for i := 0; i < remarkable.ScreenSize; i += 2 {
+	for i := 0; i < remarkable.ScreenSizeBytes; i += 2 {
 		datum := data[i]
 		if count < 254 && datum == current {
 			count++

--- a/internal/stream/handler.go
+++ b/internal/stream/handler.go
@@ -20,7 +20,7 @@ var (
 
 var rawFrameBuffer = sync.Pool{
 	New: func() any {
-		return make([]uint8, remarkable.ScreenWidth*remarkable.ScreenHeight*2) // Adjust the initial capacity as needed
+		return make([]uint8, remarkable.ScreenSize) // Adjust the initial capacity as needed
 	},
 }
 

--- a/internal/stream/handler.go
+++ b/internal/stream/handler.go
@@ -20,7 +20,7 @@ var (
 
 var rawFrameBuffer = sync.Pool{
 	New: func() any {
-		return make([]uint8, remarkable.ScreenSize) // Adjust the initial capacity as needed
+		return make([]uint8, remarkable.ScreenSizeBytes) // Adjust the initial capacity as needed
 	},
 }
 

--- a/internal/stream/handler_test.go
+++ b/internal/stream/handler_test.go
@@ -41,7 +41,7 @@ func TestStreamHandlerRaceCondition(t *testing.T) {
 		t.Fatal(err)
 	}
 	eventPublisher := pubsub.NewPubSub()
-	handler := NewStreamHandler(file, pointerAddr, eventPublisher)
+	handler := NewStreamHandler(file, pointerAddr, eventPublisher, true)
 
 	server := httptest.NewServer(handler)
 	defer server.Close()

--- a/main.go
+++ b/main.go
@@ -57,7 +57,6 @@ func main() {
 	}
 
 	file, pointerAddr, err = remarkable.GetFileAndPointer()
-	pointerAddr = pointerAddr + 8
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"embed"
+	"errors"
 	"flag"
 	"io"
 	"log"
@@ -15,12 +16,13 @@ import (
 )
 
 type configuration struct {
-	BindAddr    string `envconfig:"SERVER_BIND_ADDR" default:":2001" required:"true" description:"The server bind address"`
-	Username    string `envconfig:"SERVER_USERNAME" default:"admin"`
-	Password    string `envconfig:"SERVER_PASSWORD" default:"password"`
-	TLS         bool   `envconfig:"HTTPS" default:"true"`
-	Compression bool   `envconfig:"COMPRESSION" default:"false"`
-	DevMode     bool   `envconfig:"DEV_MODE" default:"false"`
+	BindAddr       string `envconfig:"SERVER_BIND_ADDR" default:":2001" required:"true" description:"The server bind address"`
+	Username       string `envconfig:"SERVER_USERNAME" default:"admin"`
+	Password       string `envconfig:"SERVER_PASSWORD" default:"password"`
+	TLS            bool   `envconfig:"HTTPS" default:"true"`
+	Compression    bool   `envconfig:"COMPRESSION" default:"false";`
+	RLECompression bool   `envconfig:"RLE_COMPRESSION" default:"true"`
+	DevMode        bool   `envconfig:"DEV_MODE" default:"false"`
 }
 
 const (
@@ -40,6 +42,16 @@ var (
 	tlsAssets embed.FS
 )
 
+func validateConfiguration(c *configuration) error {
+	if remarkable.Model == remarkable.RemarkablePaperPro {
+		if c.RLECompression {
+			return errors.New("RLE compression is not supported on the Remarkable Paper Pro. Disable it by setting RLE_COMPRESSION=false")
+		}
+	}
+
+	return nil
+}
+
 func main() {
 	var err error
 
@@ -54,6 +66,10 @@ func main() {
 	if err := envconfig.Process(ConfigPrefix, &c); err != nil {
 		envconfig.Usage(ConfigPrefix, &c)
 		log.Fatal(err)
+	}
+
+	if err := validateConfiguration(&c); err != nil {
+		panic(err)
 	}
 
 	file, pointerAddr, err = remarkable.GetFileAndPointer()

--- a/main.go
+++ b/main.go
@@ -16,13 +16,15 @@ import (
 )
 
 type configuration struct {
-	BindAddr       string `envconfig:"SERVER_BIND_ADDR" default:":2001" required:"true" description:"The server bind address"`
-	Username       string `envconfig:"SERVER_USERNAME" default:"admin"`
-	Password       string `envconfig:"SERVER_PASSWORD" default:"password"`
-	TLS            bool   `envconfig:"HTTPS" default:"true"`
-	Compression    bool   `envconfig:"COMPRESSION" default:"false";`
-	RLECompression bool   `envconfig:"RLE_COMPRESSION" default:"true"`
-	DevMode        bool   `envconfig:"DEV_MODE" default:"false"`
+	BindAddr             string `envconfig:"SERVER_BIND_ADDR" default:":2001" required:"true" description:"The server bind address"`
+	Username             string `envconfig:"SERVER_USERNAME" default:"admin"`
+	Password             string `envconfig:"SERVER_PASSWORD" default:"password"`
+	TLS                  bool   `envconfig:"HTTPS" default:"true"`
+	Compression          bool   `envconfig:"COMPRESSION" default:"false"`
+	RLECompression       bool   `envconfig:"RLE_COMPRESSION" default:"true"`
+	DevMode              bool   `envconfig:"DEV_MODE" default:"false"`
+	ZSTDCompression      bool   `envconfig:"ZSTD_COMPRESSION" default:"false" description:"Enable zstd compression"`
+	ZSTDCompressionLevel int    `envconfig:"ZSTD_COMPRESSION_LEVEL" default:"3" description:"Zstd compression level (1-22, where 1 is fastest and 22 is maximum compression)"`
 }
 
 const (

--- a/tools/raw_client/README.md
+++ b/tools/raw_client/README.md
@@ -1,0 +1,15 @@
+# RAW client
+
+This tool connects to a server over HTTPS, fetches raw RGBA image data, and saves it as a PNG file. It supports basic authentication and allows configuration of server details, image dimensions, and output file.
+
+Run the server on your reMarkable:
+
+```
+RK_DEV_MODE=true ./goMarkableStream
+```
+
+Run the client:
+
+```
+go run tools/client/client.go --ip 10.0.0.1  # Replace with your device IP
+```

--- a/tools/raw_client/client.go
+++ b/tools/raw_client/client.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"crypto/tls"
+	"flag"
+	"fmt"
+	"image"
+	"image/png"
+	"io"
+	"net/http"
+	"os"
+)
+
+/*
+This tool connects to a server over HTTPS, fetches raw RGBA image data,
+and saves it as a PNG file. It supports basic authentication and allows
+configuration of server details, image dimensions, and output file.
+
+Run the server on your reMarkable:
+   RK_DEV_MODE=true ./goMarkableStream
+
+Run the client:
+   go run tools/client/client.go --ip 10.0.0.1  # Replace with your device's IP
+*/
+
+func downloadRawImage(ip, port, username, password string) ([]byte, error) {
+	url := fmt.Sprintf("https://%s:%s/raw", ip, port)
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	// Create a request
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating HTTP request: %w", err)
+	}
+
+	// Add Basic Auth
+	req.SetBasicAuth(username, password)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	rawData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %w", err)
+	}
+
+	return rawData, nil
+}
+
+func convertToImage(rawData []byte, width int, height int) *image.RGBA {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	copy(img.Pix, rawData)
+	return img
+}
+
+func saveImage(img *image.RGBA, output string) error {
+	file, err := os.Create(output)
+	if err != nil {
+		return fmt.Errorf("error creating output file: %w", err)
+	}
+	defer file.Close()
+
+	if err := png.Encode(file, img); err != nil {
+		return fmt.Errorf("error encoding image to PNG: %w", err)
+	}
+
+	return nil
+}
+
+func main() {
+	ip := flag.String("ip", "127.0.0.1", "Server IP address")
+	port := flag.String("port", "2001", "Server port")
+	width := flag.Int("width", 1624, "Image width")
+	height := flag.Int("height", 2154, "Image height")
+	output := flag.String("output", "screenshot.png", "Output image file")
+	username := flag.String("username", "admin", "Basic auth username")
+	password := flag.String("password", "password", "Basic auth password")
+	flag.Parse()
+
+	rawData, err := downloadRawImage(*ip, *port, *username, *password)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+
+	img := convertToImage(rawData, *width, *height)
+
+	if err := saveImage(img, *output); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Image saved to %s\n", *output)
+}

--- a/tools/raw_client/client.go
+++ b/tools/raw_client/client.go
@@ -11,18 +11,6 @@ import (
 	"os"
 )
 
-/*
-This tool connects to a server over HTTPS, fetches raw RGBA image data,
-and saves it as a PNG file. It supports basic authentication and allows
-configuration of server details, image dimensions, and output file.
-
-Run the server on your reMarkable:
-   RK_DEV_MODE=true ./goMarkableStream
-
-Run the client:
-   go run tools/client/client.go --ip 10.0.0.1  # Replace with your device's IP
-*/
-
 func downloadRawImage(ip, port, username, password string) ([]byte, error) {
 	url := fmt.Sprintf("https://%s:%s/raw", ip, port)
 	client := &http.Client{

--- a/zstd.go
+++ b/zstd.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+type zstdResponseWriter struct {
+	io.Writer
+	http.ResponseWriter
+}
+
+func (w zstdResponseWriter) Write(b []byte) (int, error) {
+	return w.Writer.Write(b)
+}
+
+// zstdMiddleware applies zstd compression to HTTP responses.
+func zstdMiddleware(next http.Handler, compressionLevel int) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.Header.Get("Accept-Encoding"), "zstd") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Encoding", "zstd")
+
+		encoder, err := zstd.NewWriter(w, zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(compressionLevel)))
+		if err != nil {
+			http.Error(w, "Failed to create zstd encoder", http.StatusInternalServerError)
+			return
+		}
+		defer encoder.Close()
+
+		compressedWriter := zstdResponseWriter{Writer: encoder, ResponseWriter: w}
+
+		next.ServeHTTP(compressedWriter, r)
+	})
+}

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Test handler to wrap in the middleware
+func testHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, err := w.Write([]byte("Hello, World!"))
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestZstdMiddleware_NoCompression(t *testing.T) {
+	handler := zstdMiddleware(http.HandlerFunc(testHandler), 3)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	res := rec.Result()
+	defer res.Body.Close()
+
+	if res.Header.Get("Content-Encoding") != "" {
+		t.Errorf("expected no Content-Encoding, got %s", res.Header.Get("Content-Encoding"))
+	}
+
+	body, _ := io.ReadAll(res.Body)
+	if string(body) != "Hello, World!" {
+		t.Errorf("unexpected body: got %s, want %s", string(body), "Hello, World!")
+	}
+}
+
+func TestZstdMiddleware_WithCompression(t *testing.T) {
+	handler := zstdMiddleware(http.HandlerFunc(testHandler), 3)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "zstd")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	res := rec.Result()
+	defer res.Body.Close()
+
+	if res.Header.Get("Content-Encoding") != "zstd" {
+		t.Errorf("expected Content-Encoding to be zstd, got %s", res.Header.Get("Content-Encoding"))
+	}
+
+	body, _ := io.ReadAll(res.Body)
+	if string(body) == "Hello, World!" {
+		t.Errorf("response should be compressed, found plaintext in body")
+	}
+}


### PR DESCRIPTION
A lot of it is thanks to the incredible work of many contributors from https://github.com/owulveryck/goMarkableStream/issues/117, including @owulveryck, @cristiannobili, @danielealbano, @To-Si, @Jayy001, @hegzploit and more 😄 

#### What currently does not work

1. RLE is not supported
2. The `Rotate` button in the UI
3. The `Colors` button

At least this, maybe something else. 

### Main changes

Because RLE isn't supported, I added optional zstd compression middleware alongside the existing gzip. It’s faster and should use less cpu.

#### ARM64 support

- Added `const_arm64.go` with device-specific constants for the Remarkable Paper Pro.
- `fb_arm.go` renamed to `fb_rm.go` and the build tags updated to support both arm and arm64.

#### Framebuffer pointer calculation for RMPP

The logic is taken from https://github.com/owulveryck/goMarkableStream/issues/117#issuecomment-2552499815 and https://github.com/owulveryck/goMarkableStream/issues/117#issuecomment-2497802044.


#### Client side (JS) changes

- Passing `screenWidth`, `screenHeight`, `UseRLE`, etc. from the backend to the JS client.
- Fixes for the texture coordinates and the color format if the device is RMPP.

#### Input devices

RMPP uses `/dev/input/event2` and `/dev/input/event3`, so added these to the device-specific constants.

---

To run the app on Paper Pro you need to disable the RLE and you can optionally enable the compression:

```
ZSTD_COMPRESSION=true RLE_COMPRESSION=false ./goMarkableStream
```

There's also a good possibility that the Remarkable 2 is broken. I'd appreciate it if someone could check.