### PR TITLE
Prevent finding PID of xochitl_pdf_renderer when seeking framebuffer

### DIFF
--- a/internal/remarkable/findpid.go
+++ b/internal/remarkable/findpid.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 func findXochitlPID() string {
@@ -33,7 +32,7 @@ func findXochitlPID() string {
 				if err != nil {
 					continue
 				}
-				if strings.Contains(orig, "/usr/bin/xochitl") {
+				if orig == "/usr/bin/xochitl" {
 					return pid
 				}
 			}


### PR DESCRIPTION
Fixes a bug in the Remarkable Paper Pro support when launching the process with a PDF or ePub file open.  When one of these files is open the process `/usr/bin/xochitl_pdf_renderer` is running, causing the `findXochitlPID` function to fetch its PID instead of `/usr/bin/xochitl`'s PID.  Having found the wrong process, the tool is therefore unable to find the framebuffer and exits with `failed to get memory range: no mapping found for /dev/dri/card0`.

This PR changes the `findXochitlPID` function to look for exactly `/usr/bin/xochitl` instead of using `contains`.

I have not tested this change on a ReMarkable 2.