### PR TITLE
BGRA optimizations and UI improvements

### DIFF
--- a/client/glCanvas.js
+++ b/client/glCanvas.js
@@ -269,7 +269,17 @@ function convertBGRAtoRGBA(data) {
     }
 }
 
-// Call `updateTexture` with new data whenever you need to update the image
+// Redraw scene with current texture (for rotation changes without new frame data)
+function redrawScene(shouldRotate, scaleFactor) {
+    const uRotationMatrixLocation = gl.getUniformLocation(shaderProgram, 'uRotationMatrix');
+    const rotationMatrix = shouldRotate ? makeRotationZMatrix(90) : makeRotationZMatrix(0);
+    gl.uniformMatrix4fv(uRotationMatrixLocation, false, rotationMatrix);
+
+    const uScaleFactorLocation = gl.getUniformLocation(shaderProgram, 'uScaleFactor');
+    gl.uniform1f(uScaleFactorLocation, scaleFactor);
+
+    drawScene(gl, programInfo, positionBuffer, textureCoordBuffer, texture);
+}
 
 // Let's create a function that resizes the canvas element. 
 // This function will adjust the canvas's width and height attributes based on its display size, which can be set using CSS or directly in JavaScript.

--- a/client/uiInteractions.js
+++ b/client/uiInteractions.js
@@ -6,7 +6,8 @@ document.getElementById('rotate').addEventListener('click', function () {
     this.classList.toggle('toggled');
     eventWorker.postMessage({ type: 'portrait', portrait: portrait });
     resizeVisibleCanvas();
-    
+    redrawScene(portrait, 1);
+
     // Show confirmation message
     showMessage(`Display ${portrait ? 'portrait' : 'landscape'} mode activated`, 2000);
 });


### PR DESCRIPTION
## Summary

- Fix framebuffer size mismatch on reMarkable 2 firmware v3.24+
- Add delta and gzip compression for BGRA framebuffer streaming
- Remove unused compression methods (ZSTD, RLE) and HTTP-level gzip middleware
- Fix laser pointer coordinates and add throttling (~60fps with min 2px delta)
- Fix portrait mode rotation with immediate redraw on toggle
- Remove color menu, dark mode toggle, and contrast slider from frontend
- Hide layers menu unless present mode is active

## Test plan

- [ ] Test streaming on reMarkable 2 with firmware v3.24+
- [ ] Verify portrait/landscape rotation works immediately without lag
- [ ] Test laser pointer smoothness and responsiveness
- [ ] Verify present mode layers menu shows/hides correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)