### PR TITLE
Add PNG screenshot download feature

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -111,6 +111,11 @@ Currently: <span id="layerOrderStatus">Drawing on Top</span></div>
 				<div class="reconnect-spinner"></div>
 				<span class="reconnect-text">Reconnecting...</span>
 			</div>
+			<button id="screenshotBtn" class="screenshot-btn" aria-label="Download screenshot (P)" title="Download Screenshot">
+				<svg viewBox="0 0 24 24" width="24" height="24">
+					<path fill="currentColor" d="M4,4H7L9,2H15L17,4H20A2,2 0 0,1 22,6V18A2,2 0 0,1 20,20H4A2,2 0 0,1 2,18V6A2,2 0 0,1 4,4M12,7A5,5 0 0,0 7,12A5,5 0 0,0 12,17A5,5 0 0,0 17,12A5,5 0 0,0 12,7M12,9A3,3 0 0,1 15,12A3,3 0 0,1 12,15A3,3 0 0,1 9,12A3,3 0 0,1 12,9Z"/>
+				</svg>
+			</button>
 			<iframe id="content" allow="camera *;" allowfullscreen="true" frameborder="0" width="100%" height="100%" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
 		</div>
 
@@ -178,6 +183,10 @@ Currently: <span id="layerOrderStatus">Drawing on Top</span></div>
 						<div class="help-item">
 							<kbd>C</kbd>
 							<span>Copy share URL (when sharing)</span>
+						</div>
+						<div class="help-item">
+							<kbd>P</kbd>
+							<span>Download screenshot</span>
 						</div>
 						<div class="help-item">
 							<kbd>?</kbd>

--- a/client/style.css
+++ b/client/style.css
@@ -882,6 +882,72 @@ canvas.hidden {
 }
 
 /* ============================================
+   Screenshot Download Button
+   ============================================ */
+
+.screenshot-btn {
+    position: fixed;
+    top: 24px;
+    right: 24px;
+    width: 48px;
+    height: 48px;
+    background: transparent;
+    border: none;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    z-index: var(--z-status);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all var(--transition-normal);
+    color: var(--text-primary);
+}
+
+.screenshot-btn:hover {
+    transform: scale(1.1);
+}
+
+.screenshot-btn:active {
+    transform: scale(0.95);
+}
+
+.screenshot-btn:focus-visible {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
+}
+
+.screenshot-btn svg {
+    width: 20px;
+    height: 20px;
+    transition: transform var(--transition-fast);
+}
+
+
+.screenshot-btn.loading {
+    pointer-events: none;
+    opacity: 0.7;
+}
+
+.screenshot-btn.loading svg {
+    animation: spin 0.8s linear infinite;
+}
+
+/* Mobile adjustments */
+@media (max-width: 480px) {
+    .screenshot-btn {
+        top: max(16px, env(safe-area-inset-top));
+        right: max(70px, calc(env(safe-area-inset-right) + 70px));
+        width: 44px;
+        height: 44px;
+    }
+
+    .screenshot-btn svg {
+        width: 18px;
+        height: 18px;
+    }
+}
+
+/* ============================================
    Connection Error Dialog
    ============================================ */
 

--- a/client/uiInteractions.js
+++ b/client/uiInteractions.js
@@ -244,6 +244,10 @@ document.addEventListener('keydown', function(e) {
                 }
             }
             break;
+        case 'p':
+            // Download screenshot
+            downloadScreenshot();
+            break;
         case '?':
             // Help overlay
             toggleHelpOverlay(true);
@@ -543,4 +547,60 @@ document.getElementById('funnelButton').addEventListener('click', async function
         funnelBtn.classList.remove('loading');
     }
 });
+
+// Screenshot download functionality
+async function downloadScreenshot() {
+    const screenshotBtn = document.getElementById('screenshotBtn');
+    if (!screenshotBtn || screenshotBtn.classList.contains('loading')) {
+        return;
+    }
+
+    // Add loading state
+    screenshotBtn.classList.add('loading');
+
+    try {
+        const response = await authFetch('/screenshot');
+
+        if (!response.ok) {
+            throw new Error(`Failed to download screenshot: ${response.status}`);
+        }
+
+        // Get the blob from the response
+        const blob = await response.blob();
+
+        // Create a download link
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+
+        // Extract filename from Content-Disposition header if available
+        const contentDisposition = response.headers.get('Content-Disposition');
+        let filename = 'remarkable_screenshot.png';
+        if (contentDisposition) {
+            const match = contentDisposition.match(/filename="(.+)"/);
+            if (match) {
+                filename = match[1];
+            }
+        }
+
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+
+        showToast('Screenshot downloaded');
+    } catch (error) {
+        console.error('Screenshot download error:', error);
+        showToast('Failed to download screenshot');
+    } finally {
+        screenshotBtn.classList.remove('loading');
+    }
+}
+
+// Screenshot button click handler
+const screenshotBtn = document.getElementById('screenshotBtn');
+if (screenshotBtn) {
+    screenshotBtn.addEventListener('click', downloadScreenshot);
+}
 

--- a/http.go
+++ b/http.go
@@ -43,6 +43,9 @@ func setMuxer(eventPublisher *pubsub.PubSub, tm *TailscaleManager, restartCh cha
 	gestureHandler := eventhttphandler.NewGestureHandler(eventPublisher)
 	mux.Handle("/gestures", gestureHandler)
 
+	screenshotHandler := stream.NewScreenshotHandler(file, pointerAddr)
+	mux.Handle("/screenshot", screenshotHandler)
+
 	// Version endpoint
 	mux.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
 		bi, ok := debug.ReadBuildInfo()

--- a/internal/stream/screenshot.go
+++ b/internal/stream/screenshot.go
@@ -1,0 +1,72 @@
+package stream
+
+import (
+	"image"
+	"image/png"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/owulveryck/goMarkableStream/internal/remarkable"
+)
+
+// NewScreenshotHandler creates a new screenshot handler reading from file @pointerAddr
+func NewScreenshotHandler(file io.ReaderAt, pointerAddr int64) *ScreenshotHandler {
+	return &ScreenshotHandler{
+		file:        file,
+		pointerAddr: pointerAddr,
+	}
+}
+
+// ScreenshotHandler is an http.Handler that serves PNG screenshots of the framebuffer
+type ScreenshotHandler struct {
+	file        io.ReaderAt
+	pointerAddr int64
+}
+
+// ServeHTTP implements http.Handler
+func (h *ScreenshotHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	imageDataPtr := rawFrameBuffer.Get().(*[]uint8)
+	imageData := *imageDataPtr
+	defer rawFrameBuffer.Put(imageDataPtr)
+
+	_, err := h.file.ReadAt(imageData, h.pointerAddr)
+	if err != nil {
+		log.Printf("failed to read framebuffer: %v", err)
+		http.Error(w, "failed to read framebuffer", http.StatusInternalServerError)
+		return
+	}
+
+	width := remarkable.Config.Width
+	height := remarkable.Config.Height
+
+	// Create RGBA image
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+
+	// Convert framebuffer to RGBA
+	// All devices use BGRA format (4 bytes per pixel)
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			srcIdx := (y*width + x) * 4
+			dstIdx := (y*width + x) * 4
+
+			// BGRA to RGBA: swap B and R channels
+			img.Pix[dstIdx+0] = imageData[srcIdx+2] // R <- B
+			img.Pix[dstIdx+1] = imageData[srcIdx+1] // G <- G
+			img.Pix[dstIdx+2] = imageData[srcIdx+0] // B <- R
+			img.Pix[dstIdx+3] = 255                 // A (fully opaque)
+		}
+	}
+
+	// Generate filename with timestamp
+	filename := "remarkable_" + time.Now().Format("20060102_150405") + ".png"
+
+	w.Header().Set("Content-Type", "image/png")
+	w.Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
+	w.Header().Set("Cache-Control", "no-cache")
+
+	if err := png.Encode(w, img); err != nil {
+		log.Printf("failed to encode PNG: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a `/screenshot` endpoint that serves the current framebuffer as a PNG image
- Add a floating camera button in the top-right corner of the UI
- Add keyboard shortcut `P` to download screenshot
- Update help overlay with new shortcut documentation

## Details
The server-side handler reads the raw framebuffer data using the existing buffer pool, converts from BGRA to RGBA format, and encodes it as PNG with a timestamped filename (e.g., `remarkable_20240115_143022.png`).

The button has a transparent background, scales on hover, and shows a loading animation while the download is in progress.

## Test plan
- [ ] Build for reMarkable 2: `make build-remarkable-2`
- [ ] Build for Paper Pro: `make build-remarkable-paper-pro`
- [ ] Verify the camera button appears in the top-right corner
- [ ] Click the button → PNG file should download
- [ ] Press `P` key → same result
- [ ] Verify PNG opens correctly with proper dimensions
- [ ] Verify authentication works (if JWT enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)